### PR TITLE
[BY-394] Design: 온보딩 디자인 수정 및 라우트 추가

### DIFF
--- a/lib/constants/text.dart
+++ b/lib/constants/text.dart
@@ -129,5 +129,5 @@ Map<String, String> personalData = {
 };
 
 const String onboardingBeeside = 'Beeside(비사이드)는 발달장애와\n뇌병변장애 아동 보호자를 위한\n맞춤형 정보 제공 및\n커뮤니티 서비스입니다.';
-const String onboardingAutoInformation = '정보게시판에서 비사이드가 모아둔\n다양한 장애 관련 정보를\n볼 수 있습니다.';
-const String onboardingCommunity = '소통게시판에서 장애 관련 이야기를\n나누면서 정보를 공유해보세요.';
+const String onboardingAutoInformation = '정보게시판에서 비사이드가 모아둔\n다양한 장애 관련 정보를\n볼 수 있습니다.\n';
+const String onboardingCommunity = '소통게시판에서 장애 관련 이야기를\n나누면서 정보를 공유해보세요.\n\n';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:byourside/screen/authenticate/controller/auth_controller.dart';
 import 'package:byourside/screen/authenticate/controller/nickname_controller.dart';
 import 'package:byourside/screen/authenticate/setup_user.dart';
 import 'package:byourside/screen/authenticate/social_login.dart';
+import 'package:byourside/screen/onboarding.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
@@ -170,7 +171,7 @@ class MyAppState extends State<MyApp> {
               title: 'Beeside',
               initialRoute: '/login',
               routes: {
-                '/login': (context) => const SocialLogin(),
+                '/login': (context) => OnBoardingPage(),
                 '/bottom_nav': (context) => const BottomNavBar(),
                 '/user': (context) => const SetupUser(),
               },

--- a/lib/screen/authenticate/controller/auth_controller.dart
+++ b/lib/screen/authenticate/controller/auth_controller.dart
@@ -1,4 +1,5 @@
 import 'package:byourside/screen/authenticate/social_login.dart';
+import 'package:byourside/screen/onboarding.dart';
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
@@ -33,7 +34,7 @@ class AuthController extends GetxController {
 
   _moveToPage(User? user) async {
     if (user == null) {
-      Get.offAll(() => const SocialLogin());
+      Get.offAll(() => OnBoardingPage());
     } else {
       bool isUserSetUp = await checkIfUserSetUp(user.uid);
 

--- a/lib/screen/onboarding.dart
+++ b/lib/screen/onboarding.dart
@@ -11,12 +11,12 @@ import 'package:byourside/constants/colors.dart' as colors;
 class OnBoardingPage extends StatelessWidget {
   OnBoardingPage({Key? key}) : super(key: key);
   final _introKey = GlobalKey<IntroductionScreenState>();
-
-  Container _nextOrStartButton(BuildContext context, String buttonText, Function pressedFunc){
+  
+  Container _nextOrStartButton(double width, double height, String buttonText, Function pressedFunc){
     return Container(
-      margin: EdgeInsets.all(MediaQuery.of(context).size.width * (0.04)),
-      width: MediaQuery.of(context).size.width * (0.8),
-      height: MediaQuery.of(context).size.height * (0.07),
+      margin: EdgeInsets.all(width * (0.04)),
+      width: width * (0.8),
+      height: height * (0.07),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(30),
       ),
@@ -63,12 +63,18 @@ class OnBoardingPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    double deviceWidth = MediaQuery.of(context).size.width;
+    double deviceHeight = MediaQuery.of(context).size.height;
+    
     return IntroductionScreen(
       key: _introKey,
       pages: [ 
         for(int index = 0; index < pages.onboardingIconDescription.length; index++)
           PageViewModel(
-            image: pages.onboardingIconDescription[index]['icon'],
+            image: Align(
+              alignment: Alignment.bottomCenter,
+              child: pages.onboardingIconDescription[index]['icon']
+            ),
             titleWidget: Text(pages.onboardingIconDescription[index]['description'],
               textAlign: TextAlign.center,
               semanticsLabel: pages.onboardingIconDescription[index]['description'],
@@ -79,15 +85,16 @@ class OnBoardingPage extends StatelessWidget {
                 fontWeight: FontWeight.w400
             )),
             bodyWidget: Column(
-              children: [
-                SizedBox(height: MediaQuery.of(context).size.height * (0.05)),
-                _dotsIndicator(index.toDouble()),
-                index == (pages.onboardingIconDescription.length - 1) ?
-                _nextOrStartButton(context, '시작하기', () => Get.offAll(() => const SocialLogin()) )
-                : _nextOrStartButton(context, '다음', () => _introKey.currentState?.next() )
+                  children: [
+                    _dotsIndicator(index.toDouble()),
+                    index == (pages.onboardingIconDescription.length - 1) ?
+                    _nextOrStartButton(deviceWidth, deviceHeight, '시작하기', () => Get.offAll(() => const SocialLogin()) )
+                    : _nextOrStartButton(deviceWidth, deviceHeight, '다음', () => _introKey.currentState?.next() )
             ]),
-            decoration: const PageDecoration(
+            decoration: PageDecoration(
               pageColor: colors.lightPrimaryColor,
+              contentMargin : EdgeInsets.only(bottom: deviceHeight * 0.01),
+              pageMargin : EdgeInsets.only(top: deviceHeight * 0.1),
             ),
           ),
       ],


### PR DESCRIPTION
## Motivation 💡
- 기능 테스트를 위해 제거했던 온보딩 페이지 다시 추가 필요
- '다음/시작하기' 버튼 위치가 페이지마다 다름
- 전체적으로 위로 쏠려있어 수정 필요

<br>

## Key Changes 🛠️
- 앱 실행 시, 온보딩 페이지가 나오도록 수정
- 페이지별 텍스트 라인 수 통일(줄바꿈 문자 추가)로 버튼 위치 동일하게 수정
- pageDecoration에 contentMargin, pageMargin 추가해 간격 조정

<br>

## To Reviewers 😉
- 피드백주신 사항 반영해 온보딩 디자인 수정 완료했습니다.